### PR TITLE
Update to dependency in package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "gulp": "~3.8.10",
-    "gulp-less": "~2.0.1",
+    "gulp-less": "2.0.1",
     "gulp-watch": "~0.5.0",
     "gulp-coffee": "~2.2.0",
     "gulp-concat": "~2.1.7",


### PR DESCRIPTION
The gulp-less dependency throws an error on execution due to some compatibility problem between this project and a newer version of gulp-less. I found that removing the gulp-less module and reinstalling the exact version listed fixes the problem.